### PR TITLE
feat: Add company services page

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-blog/sakura-cloud-object-storage.md
+++ b/i18n/ja/docusaurus-plugin-content-blog/sakura-cloud-object-storage.md
@@ -7,6 +7,10 @@ tags:
   - Cloud Storage
   - S3 Compatible
 company: さくらインターネット
+companyInfo:
+  name: さくらインターネット
+  description: さくらインターネットは、日本のインターネットサービスプロバイダーです。
+  url: https://www.sakura.ad.jp/
 ---
 
 [さくらのクラウド オブジェクトストレージ](https://cloud.sakura.ad.jp/products/object-storage/)は、S3互換のオブジェクトストレージです。さくらインターネットの各サービス間はデータ転送量が無料です。

--- a/services/akamai-object-storage.md
+++ b/services/akamai-object-storage.md
@@ -7,6 +7,9 @@ tags:
   - Cloud Storage
   - S3 Compatible
 company: Akamai
+companyInfo:
+  description: Akamai is a global content delivery network (CDN) and cloud services company.
+  name: Akamai
 ---
 
 [Akamai Object Storage](https://www.akamai.com/products/object-storage) is an object storage service provided by Akamai, known for its CDN services. Originally offered by Linode, the service was rebranded as Akamai Object Storage after the acquisition.

--- a/services/sakura-cloud-object-storage.md
+++ b/services/sakura-cloud-object-storage.md
@@ -7,6 +7,10 @@ tags:
   - Cloud Storage
   - S3 Compatible
 company: Sakura Internet
+companyInfo:
+  name: Sakura Internet
+  description: Sakura Internet is a Japanese internet service provider.
+  url: https://www.sakura.ad.jp/
 ---
 
 [Sakura Cloud Object Storage](https://cloud.sakura.ad.jp/products/object-storage/) is an S3-compatible object storage service. Data transfer between Sakura Internet's various services is free of charge.

--- a/src/components/CompanyPage/index.js
+++ b/src/components/CompanyPage/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import BlogPostItem from '@theme/BlogPostItems/item';
+export default function CompanyPage({ services }) {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-bold mb-6">Company: {services[0]?.company}</h1>
+      <div className='grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3'>
+        {services.map((service, index) => (
+          <div key={index} className='flex'>
+            <BlogPostItem blog={{ content: service }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ServiceList/index.js
+++ b/src/components/ServiceList/index.js
@@ -1,5 +1,7 @@
+
 import React from 'react';
 import styles from './styles.module.css';
+import Translate from '@docusaurus/Translate';
 
 export default function ServiceList({ services }) {
   return (
@@ -16,7 +18,7 @@ export default function ServiceList({ services }) {
             <p>{service.description}</p>
             {service.url && (
               <a href={service.url} target="_blank" rel="noopener noreferrer" className={styles.serviceLink}>
-                詳細を見る
+                <Translate id="service.viewDetails">View details</Translate>
               </a>
             )}
           </div>
@@ -24,4 +26,4 @@ export default function ServiceList({ services }) {
       ))}
     </div>
   );
-} 
+}

--- a/src/components/ServiceList/index.js
+++ b/src/components/ServiceList/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+export default function ServiceList({ services }) {
+  return (
+    <div className={styles.serviceList}>
+      {services.map((service, index) => (
+        <div key={index} className={styles.serviceCard}>
+          {service.image && (
+            <div className={styles.serviceImage}>
+              <img src={service.image} alt={service.name} />
+            </div>
+          )}
+          <div className={styles.serviceContent}>
+            <h3>{service.name}</h3>
+            <p>{service.description}</p>
+            {service.url && (
+              <a href={service.url} target="_blank" rel="noopener noreferrer" className={styles.serviceLink}>
+                詳細を見る
+              </a>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+} 

--- a/src/components/ServiceList/styles.module.css
+++ b/src/components/ServiceList/styles.module.css
@@ -1,0 +1,61 @@
+.serviceList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+  padding: 2rem 0;
+}
+
+.serviceCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  box-shadow: var(--ifm-global-shadow-lw);
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.serviceCard:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.serviceImage {
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+}
+
+.serviceImage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.serviceContent {
+  padding: 1.5rem;
+}
+
+.serviceContent h3 {
+  margin-bottom: 0.5rem;
+  color: var(--ifm-color-primary);
+}
+
+.serviceContent p {
+  margin-bottom: 1rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.serviceLink {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: var(--ifm-color-primary);
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+.serviceLink:hover {
+  background-color: var(--ifm-color-primary-darker);
+  text-decoration: none;
+  color: white;
+}

--- a/src/pages/companies/company.js
+++ b/src/pages/companies/company.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useLocation, useHistory } from '@docusaurus/router';
+import Layout from '@theme/Layout';
+import BlogPostItem from '@theme/BlogPostItems/item';
+import Translate from '@docusaurus/Translate';
+
+export default function CompanyPage({ posts }) {
+  const location = useLocation();
+  const history = useHistory();
+  const pathSegments = location.pathname.split('/');
+  const companyName = pathSegments[pathSegments.length - 1];
+
+  // URLが /companies/company の場合は企業一覧にリダイレクト
+  if (companyName === 'company') {
+    history.push('/companies');
+    return null;
+  }
+  const companyInfo = posts.find(post => post.frontMatter.companyInfo)?.frontMatter.companyInfo || {};
+  return (
+    <Layout title={`${companyInfo.name || companyName}のサービス一覧`}>
+      <div className="container margin-vert--xl">
+        <div className='text-2xl font-bold mb-5'>
+          <Translate
+            id='companies.company'
+          >Services by </Translate>
+          {
+            companyInfo.url ? <a href={companyInfo.url} target='_blank' rel='noopener noreferrer'>{companyInfo.name || companyName}</a>
+              : companyInfo.name || companyName
+          }
+        </div>
+        <div className='text-sm text-gray-500 mb-5'>
+          {companyInfo.description}
+        </div>
+        <div className='grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3'>
+          {posts.map((metadata, index) => (
+            <div key={index} className='flex'>
+              <BlogPostItem blog={{ content: { metadata } }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </Layout>
+  );
+} 

--- a/src/pages/companies/styles.module.css
+++ b/src/pages/companies/styles.module.css
@@ -1,0 +1,45 @@
+.companyList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+  padding: 2rem 0;
+}
+
+.companyCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-card-border-radius);
+  padding: 2rem;
+  box-shadow: var(--ifm-global-shadow-lw);
+  transition: all 0.3s ease;
+}
+
+.companyCard:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.companyCard h2 {
+  margin-bottom: 1rem;
+  color: var(--ifm-color-primary);
+}
+
+.companyCard p {
+  margin-bottom: 1.5rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.companyLink {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: var(--ifm-color-primary);
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+.companyLink:hover {
+  background-color: var(--ifm-color-primary-darker);
+  text-decoration: none;
+  color: white;
+}

--- a/src/plugins/blog-plugin.js
+++ b/src/plugins/blog-plugin.js
@@ -15,23 +15,52 @@ async function blogPluginExtended(...pluginArgs) {
       const { content, actions } = params;
       const path = content.blogTagsListPath.match(/^.*?\/ja\/(.*)$/) ? '/ja/' : '/';
 
-      const companies = Array.from(new Set(content.blogPosts.filter(post => post.metadata.frontMatter.company !== undefined).map(post => post.metadata.frontMatter.company)));
+
+      const companies = Array.from(
+        new Set(
+          content.blogPosts
+            .filter(post => post.metadata.frontMatter.company !== undefined)
+            .map(post => post.metadata.frontMatter.company),
+        ),
+      );
       const promises = [];
+
+      // URL-safe slug generator for company names
+      function generateSlug(name) {
+        return name
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, '')    // remove special characters
+          .replace(/[\s_]+/g, '-')     // convert spaces and underscores to hyphens
+          .replace(/^-+|-+$/g, '');    // trim leading and trailing hyphens
+      }
+
       for (const company of companies) {
-        const key = company.toLowerCase().replace(/ /g, '-');
+        const key = generateSlug(company);
         const posts = content.blogPosts
           .filter(post => post.metadata.frontMatter.company === company)
           .map(post => post.metadata);
-        promises.push(actions.addRoute({
-          path: `${path}companies/${key}`,
-          component: '@site/src/pages/companies/company.js',
-          exact: true,
-          modules: {
-            posts: await actions.createData(`companies/${key}.json`, JSON.stringify(posts)),
-          }
-        }));
+        promises.push(
+          actions.addRoute({
+            path: `${path}companies/${key}`,
+            component: '@site/src/pages/companies/company.js',
+            exact: true,
+            modules: {
+              posts: await actions.createData(
+                `companies/${key}.json`,
+                JSON.stringify(posts),
+              ),
+            },
+          }),
+        );
       }
-      await Promise.all(promises);
+
+      try {
+        await Promise.all(promises);
+      } catch (error) {
+        console.error('会社別ルートの生成中にエラーが発生しました:', error);
+        throw error; // propagate the error to stop the build on failure
+      }
+
       const recentPostsLimit = 6
       const recentPosts = [...content.blogPosts].splice(0, recentPostsLimit)
       async function createRecentPostModule(blogPost, index) {

--- a/src/theme/BlogLayout/index.js
+++ b/src/theme/BlogLayout/index.js
@@ -4,7 +4,8 @@ import Layout from '@theme/Layout';
 import BlogSidebar from '@theme/BlogSidebar';
 import { Card, CardContent, CardFooter } from '../../components/ui/card';
 import Image from '@theme/IdealImage';
-
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
 export default function BlogLayout(props) {
   const { sidebar, toc, children, ...layoutProps } = props;
   const hasSidebar = sidebar && sidebar.items.length > 0;
@@ -34,7 +35,12 @@ export default function BlogLayout(props) {
                 />
               </CardContent>
               {frontMatter.company && <CardFooter>
-                <p className='text-sm dark:text-gray-200 font-bold'>Company: {frontMatter.company}</p>
+                <p className='text-xl dark:text-gray-200 font-bold'>
+                  <Translate id='companies.company'>Provided by </Translate>
+                  <Link to={`/companies/${frontMatter.company.toLowerCase().replace(/ /g, '-')}`}>
+                    {frontMatter.company}
+                  </Link>
+                </p>
               </CardFooter>
               }
             </Card>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 会社ごとのサービス一覧ページを追加し、各会社に関連するサービスや投稿を一覧表示できるようになりました。
  - サービス一覧表示用の新しいコンポーネントとスタイルを追加しました。
  - 各ブログ記事のサイドバーに「提供会社」情報を表示し、会社名から会社ごとのページへリンクできるようになりました。
  - ブログプラグインが会社ごとのページへの動的ルートを自動生成するようになりました。

- **スタイル**
  - 会社一覧ページおよびサービス一覧表示のデザインを改善しました。

- **ドキュメント**
  - 各サービス記事のメタデータに会社情報（会社名、説明、URL）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->